### PR TITLE
feat: Integrate organization data fetching by cluster and update rela…

### DIFF
--- a/src/features/activities/components/container/activities-container-new.tsx
+++ b/src/features/activities/components/container/activities-container-new.tsx
@@ -107,7 +107,7 @@ export function ActivitiesContainerNew({
         setEditingActivity={state.setEditingActivity}
         deletingActivity={state.deletingActivity}
         setDeletingActivity={state.setDeletingActivity}
-        organizations={[]}
+        organizations={state.organizations}
         clusters={[]}
         projects={[]}
       />

--- a/src/features/activities/components/container/use-activity-container-state.ts
+++ b/src/features/activities/components/container/use-activity-container-state.ts
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useActivities, useActivityMetrics } from "../../hooks/use-activities";
+import { useOrganizationsByCluster } from "../../hooks/use-organizations";
 import { type Activity, type ActivityFilters } from "../../types/types";
 
 interface UseActivityContainerStateProps {
@@ -66,8 +67,16 @@ export function useActivityContainerState({
     error: metricsError,
   } = useActivityMetrics(clusterId);
 
+  // Fetch organizations for the cluster
+  const {
+    data: organizationsData,
+    isLoading: _isOrganizationsLoading,
+    error: _organizationsError,
+  } = useOrganizationsByCluster(clusterId);
+
   const activities = activitiesData?.data?.data || [];
   const metricsActivities = activities; // Use the same data for now
+  const organizations = organizationsData?.data || [];
 
   // Build pagination object from API response
   const paginationData = {
@@ -112,6 +121,7 @@ export function useActivityContainerState({
     activitiesData,
     metricsActivities,
     metricsData,
+    organizations,
 
     // Loading states
     isActivitiesLoading,

--- a/src/features/activities/components/forms/activity-form-dialog.tsx
+++ b/src/features/activities/components/forms/activity-form-dialog.tsx
@@ -63,7 +63,7 @@ const activityFormSchema = z.object({
   venue: z.string().min(1, "Venue is required"),
   budget: z.number().optional(),
   objectives: z.string().optional(),
-  organizationId: z.string().min(1, "Organization is required"),
+  organizationId: z.string().min(1, "Lead partner is required"),
   clusterId: z.string().optional(),
   projectId: z.string().optional(),
   // Multi-day session fields
@@ -367,9 +367,6 @@ export function ActivityFormDialog({
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          disabled={date =>
-                            date < new Date(new Date().setHours(0, 0, 0, 0))
-                          }
                           initialFocus
                         />
                       </PopoverContent>
@@ -409,10 +406,7 @@ export function ActivityFormDialog({
                           mode="single"
                           selected={field.value}
                           onSelect={field.onChange}
-                          disabled={date =>
-                            date < form.watch("startDate") ||
-                            date < new Date(new Date().setHours(0, 0, 0, 0))
-                          }
+                          disabled={date => date < form.watch("startDate")}
                           initialFocus
                         />
                       </PopoverContent>
@@ -466,14 +460,14 @@ export function ActivityFormDialog({
               name="organizationId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Organization</FormLabel>
+                  <FormLabel>Lead Partner</FormLabel>
                   <Select
                     onValueChange={field.onChange}
                     defaultValue={field.value}
                   >
                     <FormControl>
                       <SelectTrigger>
-                        <SelectValue placeholder="Select organization" />
+                        <SelectValue placeholder="Select lead partner" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>

--- a/src/features/activities/hooks/use-organizations.ts
+++ b/src/features/activities/hooks/use-organizations.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getOrganizationsByCluster } from "@/features/organizations/actions/organizations";
+
+export function useOrganizationsByCluster(clusterId?: string) {
+  return useQuery({
+    queryKey: ["organizations", "cluster", clusterId],
+    queryFn: async () => {
+      if (!clusterId) {
+        return { success: true, data: [] };
+      }
+
+      const result = await getOrganizationsByCluster(clusterId);
+      if (!result.success) {
+        throw new Error(result.error || "Failed to fetch organizations");
+      }
+
+      return result;
+    },
+    enabled: !!clusterId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/src/features/participants/components/container/participants-tab.tsx
+++ b/src/features/participants/components/container/participants-tab.tsx
@@ -222,9 +222,8 @@ export function ParticipantsTab({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    variant="outline"
                     size="sm"
-                    className="border-gray-300 text-gray-700 hover:border-gray-400 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                    className="bg-slate-600 text-white hover:bg-slate-700 focus:ring-2 focus:ring-slate-500 focus:ring-offset-1 dark:bg-slate-700 dark:hover:bg-slate-800"
                   >
                     <Settings className="h-4 w-4" />
                     <ChevronDown className="ml-2 h-4 w-4" />
@@ -252,9 +251,8 @@ export function ParticipantsTab({
 
               <Button
                 onClick={() => setIsImportDialogOpen(true)}
-                variant="outline"
                 size="sm"
-                className="border-blue-200 bg-blue-100 text-blue-800 hover:bg-blue-200 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-400 dark:hover:bg-blue-900/30"
+                className="bg-blue-600 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:bg-blue-700 dark:hover:bg-blue-800"
               >
                 <Upload className="mr-2 h-4 w-4" />
                 Import from Excel
@@ -266,18 +264,16 @@ export function ParticipantsTab({
                     debugExcelExport();
                     toast.success("Debug info logged to console");
                   }}
-                  variant="outline"
                   size="sm"
-                  className="border-yellow-200 bg-yellow-100 text-yellow-800 hover:bg-yellow-200 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400 dark:hover:bg-yellow-900/30"
+                  className="bg-amber-600 text-white hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:ring-offset-1 dark:bg-amber-700 dark:hover:bg-amber-800"
                 >
                   🔍 Debug Excel
                 </Button>
               )}
               <Button
                 onClick={() => setIsExportDialogOpen(true)}
-                variant="outline"
                 size="sm"
-                className="border-purple-200 bg-purple-100 text-purple-800 hover:bg-purple-200 dark:border-purple-800 dark:bg-purple-900/20 dark:text-purple-400 dark:hover:bg-purple-900/30"
+                className="bg-purple-600 text-white hover:bg-purple-700 focus:ring-2 focus:ring-purple-500 focus:ring-offset-1 dark:bg-purple-700 dark:hover:bg-purple-800"
               >
                 <Download className="mr-2 h-4 w-4" />
                 Export
@@ -293,9 +289,8 @@ export function ParticipantsTab({
                       dataTableRef.current?.clearSelection();
                       setSelectedParticipants([]);
                     }}
-                    variant="outline"
                     size="sm"
-                    className="border-red-200 bg-red-100 text-red-800 hover:bg-red-200 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
+                    className="bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 focus:ring-offset-1 dark:bg-red-700 dark:hover:bg-red-800"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />
                     Delete Selected ({selectedParticipants.length})
@@ -305,9 +300,8 @@ export function ParticipantsTab({
                       dataTableRef.current?.clearSelection();
                       setSelectedParticipants([]);
                     }}
-                    variant="outline"
                     size="sm"
-                    className="border-gray-200 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:border-gray-800 dark:bg-gray-900/20 dark:text-gray-400 dark:hover:bg-gray-900/30"
+                    className="bg-gray-600 text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-1 dark:bg-gray-700 dark:hover:bg-gray-800"
                   >
                     Clear Selection
                   </Button>
@@ -320,9 +314,8 @@ export function ParticipantsTab({
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    variant="outline"
                     size="sm"
-                    className="border-gray-300 text-gray-700 hover:border-gray-400 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                    className="bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 dark:bg-indigo-700 dark:hover:bg-indigo-800"
                   >
                     <LayoutGrid className="mr-2 h-4 w-4" />
                     <span className="hidden lg:inline">Columns</span>

--- a/src/features/participants/components/data-table/columns.tsx
+++ b/src/features/participants/components/data-table/columns.tsx
@@ -93,7 +93,7 @@ export function getParticipantColumns({
           return (
             <Badge
               variant="outline"
-              className="border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-400"
+              className="border-blue-300 bg-blue-50/50 text-blue-700 hover:bg-blue-50 dark:border-blue-600 dark:bg-blue-950/20 dark:text-blue-400"
             >
               M
             </Badge>
@@ -104,14 +104,14 @@ export function getParticipantColumns({
           return (
             <Badge
               variant="outline"
-              className="border-pink-200 bg-pink-100 text-pink-800 dark:border-pink-800 dark:bg-pink-900/20 dark:text-pink-400"
+              className="border-pink-300 bg-pink-50/50 text-pink-700 hover:bg-pink-50 dark:border-pink-600 dark:bg-pink-950/20 dark:text-pink-400"
             >
               F
             </Badge>
           );
         }
 
-        return <Badge variant="outline">{sex.charAt(0).toUpperCase()}</Badge>;
+        return <Badge>{sex.charAt(0).toUpperCase()}</Badge>;
       },
     },
     {
@@ -155,15 +155,15 @@ export function getParticipantColumns({
         if (ageNum <= 35) {
           variant = "outline";
           className =
-            "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800";
+            "border-green-300 bg-green-50/50 text-green-700 hover:bg-green-50 dark:border-green-600 dark:bg-green-950/20 dark:text-green-400";
         } else if (ageNum <= 50) {
           variant = "outline";
           className =
-            "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800";
+            "border-yellow-300 bg-yellow-50/50 text-yellow-700 hover:bg-yellow-50 dark:border-yellow-600 dark:bg-yellow-950/20 dark:text-yellow-400";
         } else {
           variant = "outline";
           className =
-            "bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400 dark:border-orange-800";
+            "border-orange-300 bg-orange-50/50 text-orange-700 hover:bg-orange-50 dark:border-orange-600 dark:bg-orange-950/20 dark:text-orange-400";
         }
 
         return (
@@ -245,7 +245,7 @@ export function getParticipantColumns({
         return (
           <Badge
             variant="outline"
-            className="border-purple-200 bg-purple-100 font-mono text-purple-800 hover:bg-purple-200 dark:border-purple-800 dark:bg-purple-900/20 dark:text-purple-400"
+            className="border-purple-300 bg-purple-50/50 font-mono text-purple-700 hover:bg-purple-50 dark:border-purple-600 dark:bg-purple-950/20 dark:text-purple-400"
             title={name}
           >
             {acronym}
@@ -267,7 +267,7 @@ export function getParticipantColumns({
           <div className="flex items-center gap-2">
             <Badge
               variant="outline"
-              className="border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400"
+              className="border-emerald-300 bg-emerald-50/50 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-600 dark:bg-emerald-950/20 dark:text-emerald-400"
               title={name}
             >
               {acronym}
@@ -290,27 +290,27 @@ export function getParticipantColumns({
           employed: {
             label: "Employed",
             color:
-              "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800",
+              "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80",
           },
           unemployed: {
             label: "Unemployed",
             color:
-              "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800",
+              "bg-red-600/80 text-white hover:bg-red-700/80 dark:bg-red-700/80 dark:hover:bg-red-800/80",
           },
           "self-employed": {
             label: "Self-Employed",
             color:
-              "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800",
+              "bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80",
           },
           student: {
             label: "Student",
             color:
-              "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/20 dark:text-purple-400 dark:border-purple-800",
+              "bg-purple-600/80 text-white hover:bg-purple-700/80 dark:bg-purple-700/80 dark:hover:bg-purple-800/80",
           },
           retired: {
             label: "Retired",
             color:
-              "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-900/20 dark:text-gray-400 dark:border-gray-700",
+              "bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80",
           },
         };
 
@@ -319,17 +319,14 @@ export function getParticipantColumns({
 
         if (!statusInfo) {
           return (
-            <Badge variant="outline" className="max-w-[150px] truncate">
+            <Badge className="max-w-[150px] truncate">
               {capitalizeWords(employmentStatus)}
             </Badge>
           );
         }
 
         return (
-          <Badge
-            variant="outline"
-            className={`${statusInfo.color} max-w-[150px] truncate`}
-          >
+          <Badge className={`${statusInfo.color} max-w-[150px] truncate`}>
             {statusInfo.label}
           </Badge>
         );
@@ -346,20 +343,14 @@ export function getParticipantColumns({
 
         if (isSubscribed) {
           return (
-            <Badge
-              variant="outline"
-              className="border-green-200 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400"
-            >
+            <Badge className="bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80">
               ✓ Member
             </Badge>
           );
         }
 
         return (
-          <Badge
-            variant="outline"
-            className="border-gray-200 bg-gray-100 text-gray-600 dark:border-gray-700 dark:bg-gray-900/20 dark:text-gray-400"
-          >
+          <Badge className="bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80">
             Not Member
           </Badge>
         );
@@ -454,34 +445,32 @@ export function getParticipantColumns({
           single: {
             label: "Single",
             color:
-              "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800",
+              "bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80",
           },
           married: {
             label: "Married",
             color:
-              "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800",
+              "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80",
           },
           divorced: {
             label: "Divorced",
             color:
-              "bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400 dark:border-orange-800",
+              "bg-orange-600/80 text-white hover:bg-orange-700/80 dark:bg-orange-700/80 dark:hover:bg-orange-800/80",
           },
           widowed: {
             label: "Widowed",
             color:
-              "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-900/20 dark:text-gray-400 dark:border-gray-700",
+              "bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80",
           },
         };
 
         const statusInfo = statusMap[maritalStatus as keyof typeof statusMap];
         const displayText = statusInfo?.label || capitalizeWords(maritalStatus);
-        const colorClass = statusInfo?.color || "bg-gray-100 text-gray-800";
+        const colorClass =
+          statusInfo?.color ||
+          "bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80";
 
-        return (
-          <Badge variant="secondary" className={colorClass}>
-            {displayText}
-          </Badge>
-        );
+        return <Badge className={colorClass}>{displayText}</Badge>;
       },
     },
     {
@@ -498,39 +487,37 @@ export function getParticipantColumns({
           none: {
             label: "None",
             color:
-              "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800",
+              "bg-red-600/80 text-white hover:bg-red-700/80 dark:bg-red-700/80 dark:hover:bg-red-800/80",
           },
           primary: {
             label: "Primary",
             color:
-              "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800",
+              "bg-yellow-600/80 text-white hover:bg-yellow-700/80 dark:bg-yellow-700/80 dark:hover:bg-yellow-800/80",
           },
           secondary: {
             label: "Secondary",
             color:
-              "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800",
+              "bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80",
           },
           tertiary: {
             label: "Tertiary",
             color:
-              "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/20 dark:text-purple-400 dark:border-purple-800",
+              "bg-purple-600/80 text-white hover:bg-purple-700/80 dark:bg-purple-700/80 dark:hover:bg-purple-800/80",
           },
           university: {
             label: "University",
             color:
-              "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800",
+              "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80",
           },
         };
 
         const levelInfo = levelMap[educationLevel as keyof typeof levelMap];
         const displayText = levelInfo?.label || capitalizeWords(educationLevel);
-        const colorClass = levelInfo?.color || "bg-gray-100 text-gray-800";
+        const colorClass =
+          levelInfo?.color ||
+          "bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80";
 
-        return (
-          <Badge variant="secondary" className={colorClass}>
-            {displayText}
-          </Badge>
-        );
+        return <Badge className={colorClass}>{displayText}</Badge>;
       },
     },
     {
@@ -544,20 +531,14 @@ export function getParticipantColumns({
 
         if (ownsEnterprise) {
           return (
-            <Badge
-              variant="outline"
-              className="border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400"
-            >
+            <Badge className="bg-emerald-600/80 text-white hover:bg-emerald-700/80 dark:bg-emerald-700/80 dark:hover:bg-emerald-800/80">
               ✓ Owner
             </Badge>
           );
         }
 
         return (
-          <Badge
-            variant="outline"
-            className="border-gray-200 bg-gray-100 text-gray-600 dark:border-gray-700 dark:bg-gray-900/20 dark:text-gray-400"
-          >
+          <Badge className="border-gray-200 bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80">
             No Enterprise
           </Badge>
         );
@@ -603,10 +584,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-400"
-            >
+            <Badge className="bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80">
               {participations.length} Skills
             </Badge>
             <div className="max-w-[150px] text-xs">
@@ -633,10 +611,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-green-200 bg-green-100 text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400"
-            >
+            <Badge className="bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80">
               {completions.length} Completed
             </Badge>
             <div
@@ -671,10 +646,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-400"
-            >
+            <Badge className="bg-amber-600/80 text-white hover:bg-amber-700/80 dark:bg-amber-700/80 dark:hover:bg-amber-800/80">
               {certifications.length} Certified
             </Badge>
             <div
@@ -709,10 +681,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-purple-200 bg-purple-100 text-purple-800 dark:border-purple-800 dark:bg-purple-900/20 dark:text-purple-400"
-            >
+            <Badge className="bg-purple-600/80 text-white hover:bg-purple-700/80 dark:bg-purple-700/80 dark:hover:bg-purple-800/80">
               {participations.length} Skills
             </Badge>
             <div
@@ -747,10 +716,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-indigo-200 bg-indigo-100 text-indigo-800 dark:border-indigo-800 dark:bg-indigo-900/20 dark:text-indigo-400"
-            >
+            <Badge className="bg-indigo-600/80 text-white hover:bg-indigo-700/80 dark:bg-indigo-700/80 dark:hover:bg-indigo-800/80">
               {completions.length} Completed
             </Badge>
             <div
@@ -784,10 +750,7 @@ export function getParticipantColumns({
 
         return (
           <div className="space-y-1">
-            <Badge
-              variant="outline"
-              className="border-cyan-200 bg-cyan-100 text-cyan-800 dark:border-cyan-800 dark:bg-cyan-900/20 dark:text-cyan-400"
-            >
+            <Badge className="bg-cyan-600/80 text-white hover:bg-cyan-700/80 dark:bg-cyan-700/80 dark:hover:bg-cyan-800/80">
               {certifications.length} Certified
             </Badge>
             <div
@@ -820,8 +783,8 @@ export function getParticipantColumns({
             variant={hasSkills ? "outline" : "outline"}
             className={
               hasSkills
-                ? "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400"
-                : "border-gray-200 bg-gray-100 text-gray-600 dark:border-gray-700 dark:bg-gray-900/20 dark:text-gray-400"
+                ? "bg-emerald-600/80 text-white hover:bg-emerald-700/80 dark:bg-emerald-700/80 dark:hover:bg-emerald-800/80"
+                : "border-gray-200 bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80"
             }
           >
             {hasSkills ? "✓ Has Skills" : "No Skills"}
@@ -842,10 +805,7 @@ export function getParticipantColumns({
         if (isPWD) {
           return (
             <div className="space-y-1">
-              <Badge
-                variant="outline"
-                className="border-purple-200 bg-purple-100 text-purple-800 dark:border-purple-800 dark:bg-purple-900/20 dark:text-purple-400"
-              >
+              <Badge className="bg-purple-600/80 text-white hover:bg-purple-700/80 dark:bg-purple-700/80 dark:hover:bg-purple-800/80">
                 ✓ PWD
               </Badge>
               {disabilityType && (
@@ -861,10 +821,7 @@ export function getParticipantColumns({
         }
 
         return (
-          <Badge
-            variant="outline"
-            className="border-gray-200 bg-gray-100 text-gray-600 dark:border-gray-700 dark:bg-gray-900/20 dark:text-gray-400"
-          >
+          <Badge className="border-gray-200 bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80">
             No
           </Badge>
         );
@@ -884,32 +841,32 @@ export function getParticipantColumns({
           youth: {
             label: "Youth",
             color:
-              "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800",
+              "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80",
           },
           women: {
             label: "Women",
             color:
-              "bg-pink-100 text-pink-800 border-pink-200 dark:bg-pink-900/20 dark:text-pink-400 dark:border-pink-800",
+              "bg-pink-600/80 text-white hover:bg-pink-700/80 dark:bg-pink-700/80 dark:hover:bg-pink-800/80",
           },
           pwd: {
             label: "PWD",
             color:
-              "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/20 dark:text-purple-400 dark:border-purple-800",
+              "bg-purple-600/80 text-white hover:bg-purple-700/80 dark:bg-purple-700/80 dark:hover:bg-purple-800/80",
           },
           elderly: {
             label: "Elderly",
             color:
-              "bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400 dark:border-orange-800",
+              "bg-orange-600/80 text-white hover:bg-orange-700/80 dark:bg-orange-700/80 dark:hover:bg-orange-800/80",
           },
           refugee: {
             label: "Refugee",
             color:
-              "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800",
+              "bg-red-600/80 text-white hover:bg-red-700/80 dark:bg-red-700/80 dark:hover:bg-red-800/80",
           },
           host: {
             label: "Host",
             color:
-              "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800",
+              "bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80",
           },
         };
 
@@ -917,11 +874,7 @@ export function getParticipantColumns({
         const displayText = segmentInfo?.label || capitalizeWords(segment);
         const colorClass = segmentInfo?.color || "bg-gray-100 text-gray-800";
 
-        return (
-          <Badge variant="secondary" className={colorClass}>
-            {displayText}
-          </Badge>
-        );
+        return <Badge className={colorClass}>{displayText}</Badge>;
       },
     },
     {
@@ -945,20 +898,16 @@ export function getParticipantColumns({
           "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-900/20 dark:text-gray-400 dark:border-gray-700";
         if (income < 100000) {
           colorClass =
-            "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800";
+            "bg-red-600/80 text-white hover:bg-red-700/80 dark:bg-red-700/80 dark:hover:bg-red-800/80";
         } else if (income < 500000) {
           colorClass =
-            "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800";
+            "bg-yellow-600/80 text-white hover:bg-yellow-700/80 dark:bg-yellow-700/80 dark:hover:bg-yellow-800/80";
         } else {
           colorClass =
-            "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800";
+            "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80";
         }
 
-        return (
-          <Badge variant="outline" className={colorClass}>
-            {formattedIncome}
-          </Badge>
-        );
+        return <Badge className={colorClass}>{formattedIncome}</Badge>;
       },
     },
     {
@@ -1005,23 +954,19 @@ export function getParticipantColumns({
           "bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-900/20 dark:text-gray-400 dark:border-gray-700";
         if (children === 0) {
           colorClass =
-            "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800";
+            "bg-blue-600/80 text-white hover:bg-blue-700/80 dark:bg-blue-700/80 dark:hover:bg-blue-800/80";
         } else if (children <= 2) {
           colorClass =
-            "bg-green-100 text-green-800 border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800";
+            "bg-green-600/80 text-white hover:bg-green-700/80 dark:bg-green-700/80 dark:hover:bg-green-800/80";
         } else if (children <= 4) {
           colorClass =
-            "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800";
+            "bg-yellow-600/80 text-white hover:bg-yellow-700/80 dark:bg-yellow-700/80 dark:hover:bg-yellow-800/80";
         } else {
           colorClass =
-            "bg-red-100 text-red-800 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800";
+            "bg-red-600/80 text-white hover:bg-red-700/80 dark:bg-red-700/80 dark:hover:bg-red-800/80";
         }
 
-        return (
-          <Badge variant="outline" className={colorClass}>
-            {children}
-          </Badge>
-        );
+        return <Badge className={colorClass}>{children}</Badge>;
       },
     },
     {
@@ -1034,11 +979,10 @@ export function getParticipantColumns({
         const isStudent = row.original.isActiveStudent === "yes";
         return (
           <Badge
-            variant="outline"
             className={
               isStudent
-                ? "border-indigo-200 bg-indigo-100 text-indigo-800 dark:border-indigo-800 dark:bg-indigo-900/20 dark:text-indigo-400"
-                : "border-gray-200 bg-gray-100 text-gray-600 dark:border-gray-700 dark:bg-gray-900/20 dark:text-gray-400"
+                ? "bg-indigo-600/80 text-white hover:bg-indigo-700/80 dark:bg-indigo-700/80 dark:hover:bg-indigo-800/80"
+                : "border-gray-200 bg-gray-600/80 text-white hover:bg-gray-700/80 dark:bg-gray-700/80 dark:hover:bg-gray-800/80"
             }
           >
             {isStudent ? "✓ Student" : "Not Student"}
@@ -1056,10 +1000,7 @@ export function getParticipantColumns({
         const isTeenMother = row.original.isTeenMother === "yes";
         if (!isTeenMother) return "—";
         return (
-          <Badge
-            variant="outline"
-            className="border-pink-200 bg-pink-100 text-pink-800 dark:border-pink-800 dark:bg-pink-900/20 dark:text-pink-400"
-          >
+          <Badge className="bg-pink-600/80 text-white hover:bg-pink-700/80 dark:bg-pink-700/80 dark:hover:bg-pink-800/80">
             ✓ Teen Mother
           </Badge>
         );

--- a/src/features/participants/components/filters/simple-filters/simple-participant-filters.tsx
+++ b/src/features/participants/components/filters/simple-filters/simple-participant-filters.tsx
@@ -91,7 +91,7 @@ export function SimpleParticipantFilters({
     <div className="space-y-3">
       {/* Filtering Status Indicator */}
       {isFiltering && (
-        <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-700">
+        <div className="flex items-center gap-2 rounded-lg border border-blue-400 bg-blue-100 px-3 py-2 text-sm font-medium text-blue-800 shadow-sm dark:border-blue-600 dark:bg-blue-900/60 dark:text-blue-200">
           <Loader2 className="h-4 w-4 animate-spin" />
           <span>Filtering participants...</span>
         </div>
@@ -162,7 +162,7 @@ export function SimpleParticipantFilters({
             size="sm"
             onClick={() => clearFilters()}
             disabled={isFiltering}
-            className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="h-7 px-3 text-xs font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
           >
             {isFiltering ? (
               <>
@@ -176,13 +176,13 @@ export function SimpleParticipantFilters({
 
           {/* Search Badge */}
           {filters.search && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-300/10 ring-inset">
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1.5 text-xs font-medium text-emerald-800 shadow-sm ring-1 ring-emerald-600/20 ring-inset dark:bg-emerald-900/50 dark:text-emerald-200 dark:ring-emerald-400/30">
               Search: "{filters.search}"
               <button
                 onClick={() => removeFilter("search")}
-                className="ml-1 inline-flex h-3 w-3 items-center justify-center rounded-full bg-gray-200 text-gray-600 hover:bg-gray-300"
+                className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-emerald-200 text-emerald-700 hover:bg-emerald-300 dark:bg-emerald-800 dark:text-emerald-200 dark:hover:bg-emerald-700"
               >
-                <X className="h-2 w-2" />
+                <X className="h-2.5 w-2.5" />
               </button>
             </span>
           )}
@@ -197,14 +197,14 @@ export function SimpleParticipantFilters({
               return option ? (
                 <span
                   key={filter.key}
-                  className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-blue-700/10 ring-inset"
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-800 shadow-sm ring-1 ring-blue-600/20 ring-inset dark:bg-blue-900/50 dark:text-blue-200 dark:ring-blue-400/30"
                 >
                   {option.label}
                   <button
                     onClick={() => removeFilter(filter.key)}
-                    className="ml-1 inline-flex h-3 w-3 items-center justify-center rounded-full bg-blue-200 text-blue-600 hover:bg-blue-300"
+                    className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-200 text-blue-700 hover:bg-blue-300 dark:bg-blue-800 dark:text-blue-200 dark:hover:bg-blue-700"
                   >
-                    <X className="h-2 w-2" />
+                    <X className="h-2.5 w-2.5" />
                   </button>
                 </span>
               ) : null;
@@ -226,14 +226,14 @@ export function SimpleParticipantFilters({
               return (
                 <span
                   key={key}
-                  className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-green-700/10 ring-inset"
+                  className="inline-flex items-center gap-1 rounded-full bg-green-100 px-3 py-1.5 text-xs font-medium text-green-800 shadow-sm ring-1 ring-green-600/20 ring-inset dark:bg-green-900/50 dark:text-green-200 dark:ring-green-400/30"
                 >
                   {skillType}: {value}
                   <button
                     onClick={() => removeFilter(key)}
-                    className="ml-1 inline-flex h-3 w-3 items-center justify-center rounded-full bg-green-200 text-green-600 hover:bg-green-300"
+                    className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-green-200 text-green-700 hover:bg-green-300 dark:bg-green-800 dark:text-green-200 dark:hover:bg-green-700"
                   >
-                    <X className="h-2 w-2" />
+                    <X className="h-2.5 w-2.5" />
                   </button>
                 </span>
               );
@@ -256,14 +256,14 @@ export function SimpleParticipantFilters({
               return (
                 <span
                   key={key}
-                  className="inline-flex items-center gap-1 rounded-full bg-purple-50 px-2 py-1 text-xs font-medium text-purple-700 ring-1 ring-purple-700/10 ring-inset"
+                  className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-3 py-1.5 text-xs font-medium text-purple-800 shadow-sm ring-1 ring-purple-600/20 ring-inset dark:bg-purple-900/50 dark:text-purple-200 dark:ring-purple-400/30"
                 >
                   {label}: {value}
                   <button
                     onClick={() => removeFilter(key)}
-                    className="ml-1 inline-flex h-3 w-3 items-center justify-center rounded-full bg-purple-200 text-purple-600 hover:bg-purple-300"
+                    className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-purple-200 text-purple-700 hover:bg-purple-300 dark:bg-purple-800 dark:text-purple-200 dark:hover:bg-purple-700"
                   >
-                    <X className="h-2 w-2" />
+                    <X className="h-2.5 w-2.5" />
                   </button>
                 </span>
               );


### PR DESCRIPTION
This pull request introduces two main sets of improvements: (1) enhanced fetching and display of organizations (now called "Lead Partners") in the activities feature, and (2) a comprehensive visual update to badges and buttons in the participants feature for better clarity and consistency. Additionally, there are minor improvements to form validation and date selection behavior.

**Activities Feature Improvements:**

* Added a new hook `useOrganizationsByCluster` to fetch organizations by cluster, and integrated it into the activity container state, so the activities form now displays actual organizations (lead partners) relevant to the selected cluster instead of an empty list. [[1]](diffhunk://#diff-91b8f054a78b6746a6cb6b506438d3d5efdc3fbd432ec6e56a724f25aa0d7c63R1-R24) [[2]](diffhunk://#diff-b55e1f490ea6aae835418992d817b928d78764d29ac25d94bbdb152cd00fc503R5) [[3]](diffhunk://#diff-b55e1f490ea6aae835418992d817b928d78764d29ac25d94bbdb152cd00fc503R70-R79) [[4]](diffhunk://#diff-b55e1f490ea6aae835418992d817b928d78764d29ac25d94bbdb152cd00fc503R124) [[5]](diffhunk://#diff-174374457c9294bc3cb4cddb942262d1b5c25a9b4396cf8630190eedd4da181aL110-R110)
* Updated all references from "Organization" to "Lead Partner" in the activities form UI, including labels and placeholders, for improved clarity. [[1]](diffhunk://#diff-e5272c553926c2a167f94b7540822a66d9fde1914d0491bc2c87fdeb2626d289L469-R470) [[2]](diffhunk://#diff-e5272c553926c2a167f94b7540822a66d9fde1914d0491bc2c87fdeb2626d289L66-R66)
* Improved date selection logic in the activity form: the end date picker now only disables dates before the selected start date, making the form more user-friendly. [[1]](diffhunk://#diff-e5272c553926c2a167f94b7540822a66d9fde1914d0491bc2c87fdeb2626d289L412-R409) [[2]](diffhunk://#diff-e5272c553926c2a167f94b7540822a66d9fde1914d0491bc2c87fdeb2626d289L370-L372)

**Participants Feature Visual Updates:**

* Updated badge color schemes in the participants data table for gender, age, organization, employment status, and membership, using more distinct and accessible color classes for both light and dark modes. [[1]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL96-R96) [[2]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL107-R114) [[3]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL158-R166) [[4]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL248-R248) [[5]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL270-R270) [[6]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL293-R313) [[7]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL322-R329) [[8]](diffhunk://#diff-92d8bca7e22e263d614d0560d53919d0aa3305f407211084887073fa4035e81cL349-R353)
* Refreshed the styling of all action buttons in the participants tab (e.g., import, export, delete, clear selection, settings, columns) to use solid color backgrounds with improved contrast and focus states, replacing the previous outlined style. [[1]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L225-R226) [[2]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L255-R255) [[3]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L269-R276) [[4]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L296-R293) [[5]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L308-R304) [[6]](diffhunk://#diff-e0ba0c19383fb156caf8ed256b6f702a5568c063e83c62217d31856ff5b6e4a0L323-R318)

These changes collectively improve the usability, clarity, and visual consistency of both the activities and participants features.